### PR TITLE
Fix wrong storage showing if drive 0 is not C drive

### DIFF
--- a/About/MainWindow.xaml.cs
+++ b/About/MainWindow.xaml.cs
@@ -101,17 +101,18 @@ namespace About
             }
 
             //storage
-            var StorageInfo = new ManagementObjectSearcher(@"select * from Win32_DiskDrive");
+            System.IO.DriveInfo[] drives = System.IO.DriveInfo.GetDrives();
             string Storage = String.Empty;
 
-            foreach (ManagementObject Result in StorageInfo.Get())
+            foreach (System.IO.DriveInfo drive in drives)
             {
-                if ((String)Result["DeviceID"] == "\\\\.\\PHYSICALDRIVE0")
+                if (drive.RootDirectory.ToString() == "C:\\")
                 {
-                    Storage = Result["Size"].ToString();
+                    Storage = drive.TotalSize.ToString();
                     float StorageInKB = Int64.Parse(Storage);
                     double StorageInGB = StorageInKB / 1073741824;
                     Disk.Text = StorageInGB.ToString("F1") + " GB";
+                    break;
                 }
             }
 


### PR DESCRIPTION
I've had some time to look at the code and found a fix for this issue. It should now show the C drive capacity whether it's drive 0 or not.

![Screenshot 2022-12-17 205030](https://user-images.githubusercontent.com/44692189/208265586-c8eed4f7-be9e-44c1-91ce-783a12949d17.jpg)

Closes #2.